### PR TITLE
fix: resolve prettier errors on end of line diff only

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -12,6 +12,7 @@ const prettierConfig = {
     semi: true,
     singleQuote: false,
     tabWidth: 4,
+    endOfLine: "auto",
 };
 
 export default prettierConfig;


### PR DESCRIPTION
### What does this pull request do?

- [x] Set prettier end of line characters to auto to allow any (CRLF, LF)
- [x] Fixes the errors on format checking in the ci workflow where formatted files still raise format errors

### Related Issues

Link all issues related to this pull request

- [x] 🔗 Part of [DEV-11](https://linear.app/4sure-se/issue/DEV-11/workflow-action)

### Type of Change

Select all that apply:

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] 📚 Docs
- [ ] 🛠️ Refactoring
- [ ] 🎨 UI/UX Style
- [x] ⚙️ Workflow/Config

### Screenshots (Optional)

### Additional Information
