### PR TITLE
feat: implement edit project with form and server-side validation

### DIFF
--- a/src/app/(main)/projects/[id]/_components/action-buttons.tsx
+++ b/src/app/(main)/projects/[id]/_components/action-buttons.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import type { Projects } from "@/lib/types/project";
 import { Plus } from "lucide-react";
 import Link from "next/link";
+import EditButton from "./edit-button";
 import ExportPdfButton from "./export-pdf-button";
 import ProjectInfoButton from "./project-info-button";
 import ShareButton from "./share-button";
@@ -18,6 +19,7 @@ export default function ProjectDetailsActionButtons({
             <div className="flex items-center justify-center space-x-2">
                 <ShareButton />
                 <ExportPdfButton />
+                <EditButton projectId={project.id} />
                 <Button
                     asChild
                     variant="default"

--- a/src/app/(main)/projects/[id]/_components/edit-button.tsx
+++ b/src/app/(main)/projects/[id]/_components/edit-button.tsx
@@ -1,0 +1,25 @@
+import { Button } from "@/components/ui/button";
+import { Edit } from "lucide-react";
+import Link from "next/link";
+
+interface EditButtonProps {
+    projectId: string;
+}
+
+export default function EditButton({ projectId }: EditButtonProps) {
+    return (
+        <Button
+            asChild
+            variant="default"
+            size="default"
+            className="flex items-center gap-1 bg-blue-700 px-2 py-1 text-xs text-white hover:bg-blue-800 sm:gap-2 sm:text-sm md:text-sm"
+        >
+            <Link href={`/projects/${projectId}/edit`}>
+                <>
+                    <Edit className="h-3 w-3 sm:h-4 sm:w-4 md:h-5 md:w-5" />
+                    <span className="xs:inline">Edit</span>
+                </>
+            </Link>
+        </Button>
+    );
+}

--- a/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.config.ts
+++ b/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.config.ts
@@ -1,0 +1,68 @@
+import type { FieldConfig, FormField } from "@/lib/types/form.types";
+import type { UpdateProjectDTO } from "@/lib/types/project/project.types";
+
+// field details of the project form
+export const updateProjectFormConfig: Record<
+    FormField<UpdateProjectDTO>,
+    FieldConfig<UpdateProjectDTO>
+> = {
+    contractId: {
+        name: "contractId",
+        label: "Contract ID",
+        placeholder: "Enter contract ID",
+        default: "",
+        isOptional: true,
+    },
+    contractName: {
+        name: "contractName",
+        label: "Contract Name",
+        placeholder: "Enter contract name",
+        default: "",
+        isOptional: true,
+    },
+    contractor: {
+        name: "contractor",
+        label: "Contractor",
+        placeholder: "Enter contractor name",
+        default: "",
+        isOptional: true,
+    },
+    location: {
+        name: "location",
+        label: "Location",
+        placeholder: "Enter location",
+        default: "Iloilo",
+        isOptional: true,
+    },
+    dateStarted: {
+        name: "dateStarted",
+        label: "Date Started",
+        placeholder: "Select date",
+        type: "date",
+        default: new Date(),
+        isOptional: true,
+    },
+    materialsEngineer: {
+        name: "materialsEngineer",
+        label: "Materials Engineer",
+        placeholder: "Enter materials engineer name",
+        default: "",
+        isOptional: true,
+    },
+    limits: {
+        name: "limits",
+        label: "Limits",
+        placeholder: "Enter limits",
+        type: "textarea",
+        default: "",
+        isOptional: true,
+    },
+    contractCost: {
+        name: "contractCost",
+        label: "Contract Cost",
+        placeholder: "Enter contract cost",
+        type: "number",
+        default: 0,
+        isOptional: true,
+    },
+} as const;

--- a/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.schema.ts
+++ b/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.schema.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const updateProjectSchema = z.object({
+    contractId: z
+        .string()
+        .trim()
+        .min(1, "Contract ID is required")
+        .max(50, "Contract ID cannot exceed 50 characters")
+        .optional(),
+    contractName: z
+        .string()
+        .trim()
+        .min(1, "Contract Name is required")
+        .max(100, "Contract Name cannot exceed 100 characters")
+        .optional(),
+    contractor: z
+        .string()
+        .trim()
+        .min(1, "Contractor is required")
+        .max(100, "Contractor name cannot exceed 100 characters")
+        .optional(),
+    location: z
+        .string()
+        .trim()
+        .max(100, "Location cannot exceed 100 characters")
+        .optional()
+        .nullable(),
+    dateStarted: z.coerce
+        .date({
+            required_error: "Date Started is required",
+            invalid_type_error: "Invalid date format",
+        })
+        .optional(),
+    materialsEngineer: z
+        .string()
+        .trim()
+        .min(1, "Materials Engineer is required")
+        .max(100, "Materials Engineer name cannot exceed 100 characters")
+        .optional(),
+    limits: z
+        .string()
+        .trim()
+        .max(500, "Limits cannot exceed 500 characters")
+        .optional()
+        .nullable(),
+    contractCost: z.coerce
+        .number({
+            required_error: "Contract Cost is required",
+            invalid_type_error: "Contract Cost must be a number",
+        })
+        .positive("Contract Cost must be a positive number")
+        .optional(),
+});

--- a/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.tsx
+++ b/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import Form from "next/form";
+import { useRouter } from "next/navigation";
+
+import FormRow from "@/components/custom/form-row";
+import { Form as UIForm } from "@/components/ui/form";
+import { useFormAction } from "@/hooks/use-form-action";
+import { type Callbacks } from "@/lib/types/actions.types";
+import type {
+    ProjectActionErrors,
+    ProjectActionState,
+    ProjectDTO,
+    UpdateProjectDTO,
+} from "@/lib/types/project/project.types";
+import { withCallbacks } from "@/lib/utils";
+
+import { ProjectFormField } from "@/app/(main)/projects/_components/project-form";
+import { formLayout } from "@/app/(main)/projects/_components/project-form/project-form.config";
+import ButtonWithLoader from "@/components/custom/button-with-loader";
+import { updateProjectFormConfig } from "./update-project-form.config";
+import { updateProjectSchema } from "./update-project-form.schema";
+
+interface UpdateProjectFormProps {
+    projectId: string;
+    action: (
+        projectId: string,
+        previousState: ProjectActionState,
+        formData: FormData,
+    ) => Promise<ProjectActionState>;
+    defaultValues: UpdateProjectDTO;
+}
+
+export default function UpdateProjectForm({
+    projectId,
+    action,
+    defaultValues,
+}: UpdateProjectFormProps) {
+    const router = useRouter();
+
+    // server action callbacks on success or error
+    const callbacks: Callbacks<ProjectDTO | null, ProjectActionErrors> = {
+        // on server action success
+        onSuccess: (_data) => {
+            router.back();
+            form.reset();
+        },
+        // on server action error
+        onError: (error) => {
+            if (error.general)
+                form.setError("root", { message: error.general[0] });
+            if (error.contractId)
+                form.setError("contractId", { message: error.contractId[0] });
+        },
+    };
+
+    const { form, isPending, startAction, submitAction } = useFormAction({
+        action: withCallbacks(action.bind(null, projectId), callbacks),
+        schema: updateProjectSchema,
+        defaultValues,
+    });
+
+    // handle form submission and call the server action with the form data
+    const handleSubmit = form.handleSubmit((_, e) => {
+        startAction(() => {
+            const formData = new FormData(e?.target as HTMLFormElement);
+            submitAction(formData);
+        });
+    });
+
+    return (
+        // shadcn form component to handle form state and validation
+        <UIForm {...form}>
+            {/* next/form to handle form submission */}
+            <Form
+                action={submitAction}
+                onSubmit={handleSubmit}
+                noValidate
+                className="space-y-8"
+            >
+                {/* form fields */}
+                <div className="space-y-6">
+                    {/* render each row based on the layout in config */}
+                    {formLayout.map((row, rowIndex) => (
+                        <FormRow
+                            className="gap-4 md:gap-10"
+                            key={`row-${rowIndex}`}
+                        >
+                            {/* render each field on the row*/}
+                            {row.map((fieldName) => (
+                                <ProjectFormField<UpdateProjectDTO>
+                                    key={fieldName}
+                                    control={form.control}
+                                    fieldDetails={
+                                        updateProjectFormConfig[fieldName]
+                                    }
+                                />
+                            ))}
+                        </FormRow>
+                    ))}
+                </div>
+
+                {/* display general server error */}
+                {form.formState.errors.root ? (
+                    <span className="font-medium text-destructive">
+                        {form.formState.errors.root.message}
+                    </span>
+                ) : null}
+
+                {/* submit button */}
+                <div className="flex justify-end">
+                    <ButtonWithLoader
+                        isPending={isPending}
+                        text="Add"
+                        type="submit"
+                    />
+                </div>
+            </Form>
+        </UIForm>
+    );
+}

--- a/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.tsx
+++ b/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.tsx
@@ -111,7 +111,7 @@ export default function UpdateProjectForm({
                 <div className="flex justify-end">
                     <ButtonWithLoader
                         isPending={isPending}
-                        text="Add"
+                        text="Update"
                         type="submit"
                     />
                 </div>

--- a/src/app/(main)/projects/[id]/edit/page.tsx
+++ b/src/app/(main)/projects/[id]/edit/page.tsx
@@ -22,7 +22,7 @@ export default async function ProjectEditPage({
         <div className="mx-auto max-w-7xl py-2 md:py-4">
             <SectionHeader
                 title="Edit Project"
-                description={`Update information about project ${project.id}`}
+                description={`Update information about project ${project.contractId}`}
             />
             <UpdateProjectForm
                 projectId={id}

--- a/src/app/(main)/projects/[id]/edit/page.tsx
+++ b/src/app/(main)/projects/[id]/edit/page.tsx
@@ -1,8 +1,34 @@
+import SectionHeader from "@/components/custom/section-header";
+import { tryCatch } from "@/lib/utils";
+import { updateProject } from "@/server/actions/projects/update-project";
+import { ProjectService } from "@/server/services/project.service";
+import UpdateProjectForm from "./_components/update-project-form/update-project-form";
+
 export default async function ProjectEditPage({
     params,
 }: {
     params: Promise<{ id: string }>;
 }) {
     const { id } = await params;
-    return <div>Edit Project: {id}</div>;
+    const { data: project, error: getProjectError } = await tryCatch(
+        ProjectService.getProjectById(id),
+    );
+
+    if (getProjectError) {
+        throw getProjectError;
+    }
+
+    return (
+        <div className="mx-auto max-w-7xl py-2 md:py-4">
+            <SectionHeader
+                title="Edit Project"
+                description={`Update information about project ${project.id}`}
+            />
+            <UpdateProjectForm
+                projectId={id}
+                action={updateProject}
+                defaultValues={project}
+            />
+        </div>
+    );
 }

--- a/src/server/actions/projects/update-project.ts
+++ b/src/server/actions/projects/update-project.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { updateProjectSchema } from "@/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.schema";
+import type { ProjectActionState } from "@/lib/types/project/project.types";
+import { tryCatch } from "@/lib/utils";
+import { errorHandler } from "@/lib/utils/error-handler";
+import { ProjectService } from "@/server/services/project.service";
+import { revalidatePath } from "next/cache";
+
+export async function updateProject(
+    projectId: string,
+    _initialState: ProjectActionState,
+    formData: FormData,
+): Promise<ProjectActionState> {
+    // make an object from the received form data
+    const formDataObj = Object.fromEntries(formData.entries());
+
+    // validate the object if it is in the correct format
+    const {
+        data: parsedData,
+        error: parseError,
+        success: parseSuccess,
+    } = updateProjectSchema.safeParse(formDataObj);
+
+    // if it has errors return an object with the error message of each field
+    if (!parseSuccess) {
+        return {
+            success: false,
+            error: parseError.flatten().fieldErrors,
+        };
+    }
+
+    // create a new project with the parsed data
+    const { data, error: cError } = await tryCatch(
+        ProjectService.updateProject(projectId, parsedData),
+    );
+
+    // if there's an error in creating the project in the db
+    if (cError) {
+        const error = errorHandler(cError);
+        // if the target is undefined set it to a general error
+        const errorKey =
+            typeof error.target === "string" && error.target
+                ? error.target
+                : "general";
+        return {
+            success: false,
+            error: { [errorKey]: [error.message] },
+        };
+    }
+
+    // refetch projects on the /projects route
+    revalidatePath("/projects");
+
+    return {
+        success: true,
+        data,
+    };
+}

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -1,0 +1,2 @@
+export { ProjectService } from "./project.service";
+export { WorkItemService } from "./work-item.service";


### PR DESCRIPTION
### What does this pull request do?

- [x] Implements the update project form on the edit project page
- [x] with complete form validation
- [x] with server-side validation (i.e. when no changes are made, existing contract ID)
- [x] Adds an edit action button on the project details page

### Related Issues

Link all issues related to this pull request

- [x] 🔗 Part of [DEV-21](https://linear.app/4sure-se/issue/DEV-21/edit-project)

### Type of Change

Select all that apply:

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Docs
- [ ] 🛠️ Refactoring
- [x] 🎨 UI/UX Style
- [ ] ⚙️ Workflow/Config
- [ ] 🧪 Testing

### Screenshots (Optional)
edit project page
![image](https://github.com/user-attachments/assets/59ab7efa-c102-409c-9c2a-374713a2d56f)
edit button on the project details page
![image](https://github.com/user-attachments/assets/100da248-8c2e-4dff-bea5-f981ef5f8220)
when submitting with no changes
![image](https://github.com/user-attachments/assets/be303efd-8cc8-4528-a1ac-ad99fe5c9a40)

### Additional Information
