### PR TITLE
refactor: use startTransition instead of useTransition hook

### DIFF
--- a/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.tsx
+++ b/src/app/(main)/projects/[id]/edit/_components/update-project-form/update-project-form.tsx
@@ -19,6 +19,7 @@ import { ProjectFormField } from "@/app/(main)/projects/_components/project-form
 import { formLayout } from "@/app/(main)/projects/_components/project-form/project-form.config";
 import ButtonWithLoader from "@/components/custom/button-with-loader";
 import { Edit } from "lucide-react";
+import { startTransition } from "react";
 import { updateProjectFormConfig } from "./update-project-form.config";
 import { updateProjectSchema } from "./update-project-form.schema";
 
@@ -43,8 +44,10 @@ export function UpdateProjectForm({
     const callbacks: Callbacks<ProjectDTO | null, ProjectActionErrors> = {
         // on server action success
         onSuccess: (_data) => {
-            router.back();
-            form.reset();
+            startTransition(() => {
+                router.push(`/projects/${projectId}`);
+                form.reset();
+            });
         },
         // on server action error
         onError: (error) => {
@@ -55,7 +58,7 @@ export function UpdateProjectForm({
         },
     };
 
-    const { form, isPending, startAction, submitAction } = useFormAction({
+    const { form, isPending, submitAction } = useFormAction({
         action: withCallbacks(action.bind(null, projectId), callbacks),
         schema: updateProjectSchema,
         defaultValues,
@@ -63,7 +66,7 @@ export function UpdateProjectForm({
 
     // handle form submission and call the server action with the form data
     const handleSubmit = form.handleSubmit((_, e) => {
-        startAction(() => {
+        startTransition(() => {
             const formData = new FormData(e?.target as HTMLFormElement);
             submitAction(formData);
         });

--- a/src/app/(main)/projects/[id]/work-items/_components/add-project-work-item-form/add-project-work-item-form.tsx
+++ b/src/app/(main)/projects/[id]/work-items/_components/add-project-work-item-form/add-project-work-item-form.tsx
@@ -22,6 +22,7 @@ import type {
 } from "@/lib/types/work-item/";
 import { withCallbacks } from "@/lib/utils";
 
+import { startTransition } from "react";
 import { createProjectWorkItemSchema } from "./add-project-work-item-form.schema";
 import { WorkItemSelect } from "./work-item-select";
 
@@ -42,8 +43,6 @@ export function AddProjectWorkItemForm({
 }: AddProjectWorkItemFormProps) {
     const defaultValues = { workItemId: "", quantity: 0 };
 
-    // const router = useRouter();
-
     // server action callbacks on success or error
     const callbacks: Callbacks<
         WorkItemDefinitionDTO | null,
@@ -51,8 +50,9 @@ export function AddProjectWorkItemForm({
     > = {
         // on server action success
         onSuccess: (data) => {
-            form.reset();
-            // router.push(`/projects/${projectId}`);
+            startTransition(() => {
+                form.reset();
+            });
             console.log("success", data);
         },
         // on server action error
@@ -64,7 +64,7 @@ export function AddProjectWorkItemForm({
         },
     };
 
-    const { form, isPending, startAction, submitAction } = useFormAction({
+    const { form, isPending, submitAction } = useFormAction({
         action: withCallbacks(action.bind(null, projectId), callbacks), // bind projectId to the action
         schema: createProjectWorkItemSchema,
         defaultValues,
@@ -72,12 +72,11 @@ export function AddProjectWorkItemForm({
 
     // handle form submission and call the server action with the form data
     const handleSubmit = form.handleSubmit((_, e) => {
-        startAction(() => {
+        startTransition(() => {
             const formData = new FormData(e?.target as HTMLFormElement);
             submitAction(formData);
         });
     });
-
     // work item unit
     const selectedWorkItemId = form.watch("workItemId");
     const selectedWorkItem = workItemDefinitions.find(

--- a/src/app/(main)/projects/[id]/work-items/_components/update-project-work-item-form/update-actions.tsx
+++ b/src/app/(main)/projects/[id]/work-items/_components/update-project-work-item-form/update-actions.tsx
@@ -33,7 +33,7 @@ export function UpdateProjectWorkItemActions({
                             variant="ghost"
                             size="icon"
                             className="h-8 w-8 cursor-pointer text-green-600 hover:bg-green-100 hover:text-green-700"
-                            disabled={isDisabled || isSubmittingEdit} // Disable when submitting
+                            disabled={isDisabled || isSubmittingEdit}
                             aria-label="Save quantity"
                         >
                             {isSubmittingEdit ? (
@@ -56,7 +56,7 @@ export function UpdateProjectWorkItemActions({
                             size="icon"
                             className="h-8 w-8 cursor-pointer text-muted-foreground hover:bg-gray-100 hover:text-gray-700"
                             onClick={onCancel}
-                            disabled={isSubmittingEdit} // Also disable cancel during submission
+                            disabled={isSubmittingEdit}
                             aria-label="Cancel edit"
                         >
                             <X className="h-4 w-4" />

--- a/src/app/(main)/projects/new/_components/create-project-form/create-project-form.tsx
+++ b/src/app/(main)/projects/new/_components/create-project-form/create-project-form.tsx
@@ -21,6 +21,7 @@ import {
     ProjectFormField,
 } from "@/app/(main)/projects/_components/project-form";
 import { Plus } from "lucide-react";
+import { startTransition } from "react";
 import { createProjectFormConfig } from "./create-project-form.config";
 import { createProjectSchema } from "./create-project-form.schema";
 
@@ -42,8 +43,10 @@ export function CreateProjectForm({
     const callbacks: Callbacks<ProjectDTO | null, ProjectActionErrors> = {
         // on server action success
         onSuccess: (data) => {
-            router.push(`/projects/${data?.id}/work-items`);
-            form.reset();
+            startTransition(() => {
+                router.push(`/projects/${data?.id}/work-items`);
+                form.reset();
+            });
         },
         // on server action error
         onError: (error) => {
@@ -54,7 +57,7 @@ export function CreateProjectForm({
         },
     };
 
-    const { form, isPending, startAction, submitAction } = useFormAction({
+    const { form, isPending, submitAction } = useFormAction({
         action: withCallbacks(action, callbacks),
         schema: createProjectSchema,
         defaultValues,
@@ -62,7 +65,7 @@ export function CreateProjectForm({
 
     // handle form submission and call the server action with the form data
     const handleSubmit = form.handleSubmit((_, e) => {
-        startAction(() => {
+        startTransition(() => {
             const formData = new FormData(e?.target as HTMLFormElement);
             submitAction(formData);
         });

--- a/src/hooks/use-form-action.ts
+++ b/src/hooks/use-form-action.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useActionState, useTransition } from "react";
+import { useActionState } from "react";
 import { useForm, type UseFormProps } from "react-hook-form";
 import { type z } from "zod";
 
@@ -40,8 +40,6 @@ export function useFormAction<
 >) {
     type TFormData = z.infer<TForm>;
 
-    const [, startTransition] = useTransition();
-
     const initialActionState: ActionState<TData | null, TError> = {
         // initial action state
         success: true,
@@ -65,7 +63,6 @@ export function useFormAction<
     return {
         form,
         actionState,
-        startAction: startTransition,
         submitAction,
         isPending,
     };


### PR DESCRIPTION
### What does this pull request do?

- [x] Refactors the useFormAction hook to use react's startTransition function instead of destructuring from the useTransition hook
- [x] Apply startTransition to server action calls

### Related Issues

Link all issues related to this pull request

- [x] 🔗 Part of [DEV-86](https://linear.app/4sure-se/issue/DEV-86/refactor-useformaction-hook)

### Type of Change

Select all that apply:

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Docs
- [x] 🛠️ Refactoring
- [ ] 🎨 UI/UX Style
- [ ] ⚙️ Workflow/Config
- [ ] 🧪 Testing

### Screenshots (Optional)
sample usage of startTransition
![image](https://github.com/user-attachments/assets/fa921d4a-c9b4-416e-8494-7bdf7d0b157d)

 new usage of useFormAction
![image](https://github.com/user-attachments/assets/b3c8eccd-8882-49f3-a157-a7b3126d073d)

### Additional Information
