### PR TITLE
chore: apply path revalidation to server actions

### DIFF
--- a/src/server/actions/projects/create-project-work-item.ts
+++ b/src/server/actions/projects/create-project-work-item.ts
@@ -43,7 +43,10 @@ export async function createProjectWorkItem(
         return { success: false, error: { general: [errorMsg] } };
     }
 
-    revalidatePath("/projects");
+    // refetch project work items data on the /projects/[id]/work-items route
+    revalidatePath(`/projects`);
+    revalidatePath(`/projects/[id]`);
+    revalidatePath(`/projects/[id]/work-items`);
 
     return {
         success: true,

--- a/src/server/actions/projects/delete-project-work-item.ts
+++ b/src/server/actions/projects/delete-project-work-item.ts
@@ -22,7 +22,10 @@ export async function deleteProjectWorkItem(
         return { success: false, error: { general: [errorMsg] } };
     }
 
-    revalidatePath("/projects");
+    // refetch project work items data on the /projects/[id]/work-items route
+    revalidatePath(`/projects`);
+    revalidatePath(`/projects/[id]`);
+    revalidatePath(`/projects/[id]/work-items`);
 
     return {
         success: true,

--- a/src/server/actions/projects/update-project-work-item.ts
+++ b/src/server/actions/projects/update-project-work-item.ts
@@ -47,7 +47,9 @@ export async function updateProjectWorkItem(
         };
     }
 
-    revalidatePath("/projects");
+    revalidatePath(`/projects`);
+    revalidatePath(`/projects/[id]`);
+    revalidatePath(`/projects/[id]/work-items`);
 
     return {
         success: true,

--- a/src/server/actions/projects/update-project.ts
+++ b/src/server/actions/projects/update-project.ts
@@ -51,6 +51,7 @@ export async function updateProject(
 
     // refetch projects on the /projects route
     revalidatePath("/projects");
+    revalidatePath(`/projects/${projectId}`);
 
     return {
         success: true,

--- a/src/server/actions/projects/update-test-on-file.ts
+++ b/src/server/actions/projects/update-test-on-file.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/lib/types/project-test/project-test.types";
 import { tryCatch } from "@/lib/utils/try-catch";
 import { ProjectService } from "@/server/services/project.service";
+import { revalidatePath } from "next/cache";
 
 export const updateProjectTestOnFile = async (
     id: string,
@@ -29,6 +30,9 @@ export const updateProjectTestOnFile = async (
             };
         }
 
+        revalidatePath("/projects");
+        revalidatePath(`/projects/[id]`);
+
         return { success: true, data: updatedWorkItemTest };
     }
 
@@ -44,6 +48,9 @@ export const updateProjectTestOnFile = async (
                 error: updateError.message || "Error updating material test",
             };
         }
+
+        revalidatePath("/projects");
+        revalidatePath(`/projects/[id]`);
 
         return { success: true, data: updatedMaterialTest };
     }


### PR DESCRIPTION
### What does this pull request do?

- [x] Applies path revalidation through all server actions to invalidate the server cache for the routes after mutations

### Related Issues

Link all issues related to this pull request

- [x] 🔗 Part of [DEV-75](https://linear.app/4sure-se/issue/DEV-75/apply-correct-path-revalidation-on-server-actions)

### Type of Change

Select all that apply:

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Docs
- [ ] 🛠️ Refactoring
- [ ] 🎨 UI/UX Style
- [ ] ⚙️ Workflow/Config
- [ ] 🧪 Testing

### Screenshots (Optional)

### Additional Information
