### PR TITLE
test: update project service tests, vitest config, and ci workflow for test db integration in unit tests

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -10,7 +10,7 @@ jobs:
             matrix:
                 node-version: [22.x]
         env:
-            DATABASE_URL: ${{ secrets.DATABASE_URL }}
+            DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
             DIRECT_URL: ${{ secrets.DIRECT_URL }}
             NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
             NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -7,10 +7,9 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [20.x, 22.x]
-
+                node-version: [22.x]
         env:
-            DATABASE_URL: ${{ secrets.DATABASE_URL }}
+            DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
             DIRECT_URL: ${{ secrets.DIRECT_URL }}
             NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
             NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     },
     "devDependencies": {
         "@chromatic-com/storybook": "^3.2.6",
-        "@radix-ui/react-avatar": "^1.1.3",
         "@storybook/addon-essentials": "^8.6.12",
         "@storybook/addon-onboarding": "^8.6.12",
         "@storybook/blocks": "^8.6.12",

--- a/src/lib/stubs/project.stub.ts
+++ b/src/lib/stubs/project.stub.ts
@@ -1,13 +1,14 @@
 import type { ProjectDTO } from "@/lib/types/project";
 import type { Project } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
+import { v4 as uuidv4 } from "uuid";
 
 export const fakeProject: Project = {
-    id: "fake-project-id",
+    id: uuidv4(),
     contractId: "fake-contract-id",
     contractName: "Fake Contract Name",
-    dateStarted: new Date(),
-    updatedAt: new Date(),
+    dateStarted: new Date("2025-01-01"),
+    updatedAt: new Date("2025-12-01"),
     contractCost: Decimal(1000),
     contractor: "Fake Contractor",
     materialsEngineer: "Fake Engineer",

--- a/src/server/data-access/project/project.ts
+++ b/src/server/data-access/project/project.ts
@@ -133,3 +133,7 @@ export async function generateProjectShareLink(
 
     return { token };
 }
+
+export async function clearProjects(): Promise<void> {
+    await db.project.deleteMany();
+}

--- a/src/server/services/__tests__/project.service.test.ts
+++ b/src/server/services/__tests__/project.service.test.ts
@@ -1,76 +1,68 @@
+import * as projectAdapter from "@/lib/adapters/project";
+import { fakeProject, fakeProjectDTO } from "@/lib/stubs/project.stub";
+import * as projectDataAccess from "@/server/data-access/project/project";
 import { ProjectService } from "@/server/services/project.service";
 
-import { projectToDTO } from "@/lib/adapters/project";
-import {
-    deleteProject,
-    getProjectById,
-} from "@/server/data-access/project/project";
-
-import { fakeProject, fakeProjectDTO } from "@/lib/stubs/project.stub";
-
-vi.mock("@/server/data-access/project/project", () => ({
-    getProjectById: vi.fn(),
-    deleteProject: vi.fn(),
-}));
-vi.mock("@/lib/adapters/project", () => ({
-    projectToDTO: vi.fn(),
-}));
-
 describe("ProjectService", () => {
-    // add other unit tests here
-
-    // Delete Project Unit Tests
     describe("deleteProject", () => {
         const projectIdToDelete = fakeProject.id;
 
-        beforeEach(() => {
+        beforeEach(async () => {
+            // before each test
+            // clear all mocks and clear the projects and all associated dat
             vi.clearAllMocks();
+            await projectDataAccess.clearProjects();
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
         });
 
         it("successfully deletes an existing project and returns its DTO", async () => {
-            vi.mocked(getProjectById).mockResolvedValue(fakeProject);
-            vi.mocked(deleteProject).mockResolvedValue(fakeProject);
-            vi.mocked(projectToDTO).mockReturnValue(fakeProjectDTO);
+            // create a project in the db
+            await projectDataAccess.createProject(fakeProject);
 
             const result =
                 await ProjectService.deleteProject(projectIdToDelete);
 
-            expect(deleteProject).toHaveBeenCalledWith(projectIdToDelete);
-            expect(projectToDTO).toHaveBeenCalledWith(fakeProject);
+            // check if the project was deleted
             expect(result).toEqual(fakeProjectDTO);
         });
 
         it("throws a vague error when the db fails", async () => {
-            const databaseError = new Error("DB Error");
-            vi.mocked(getProjectById).mockResolvedValue(fakeProject);
-            vi.mocked(deleteProject).mockRejectedValue(databaseError);
+            await projectDataAccess.createProject(fakeProject);
 
+            const dbError = new Error("DB Error");
+
+            // mock the deleteProject function to throw an error
+            const deleteProjectSpy = vi
+                .spyOn(projectDataAccess, "deleteProject")
+                .mockRejectedValue(dbError);
+
+            // check if the error is thrown
             await expect(
                 ProjectService.deleteProject(projectIdToDelete),
             ).rejects.toThrow(
                 `[Service] Failed to delete project ID: ${projectIdToDelete}`,
             );
 
-            expect(projectToDTO).not.toHaveBeenCalled();
+            expect(deleteProjectSpy).toHaveBeenCalledWith(projectIdToDelete);
         });
 
         it("throws a not found error when project doesn't exist", async () => {
-            vi.mocked(getProjectById).mockResolvedValue(null);
-
+            // directly call the deleteProject function without creating the project
+            // and check if the error is thrown
             await expect(
                 ProjectService.deleteProject(projectIdToDelete),
             ).rejects.toThrow(
                 `[Service] Project with ID ${projectIdToDelete} not found`,
             );
-
-            expect(deleteProject).not.toHaveBeenCalled();
-            expect(projectToDTO).not.toHaveBeenCalled();
         });
-
         it("throws an error when project DTO conversion fails", async () => {
-            vi.mocked(getProjectById).mockResolvedValue(fakeProject);
-            vi.mocked(deleteProject).mockResolvedValue(fakeProject);
-            vi.mocked(projectToDTO).mockReturnValue(null);
+            await projectDataAccess.createProject(fakeProject);
+
+            // mock the projectToDTO function to return null (failed conversion)
+            vi.spyOn(projectAdapter, "projectToDTO").mockReturnValue(null);
 
             await expect(
                 ProjectService.deleteProject(projectIdToDelete),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -73,6 +73,10 @@ export default defineConfig({
                     environment: "jsdom",
                     globals: true,
                     setupFiles: ["src/server/services/__tests__/setup.ts"],
+                    env: {
+                        NODE_ENV: "test",
+                        SKIP_ENV_VALIDATION: "true",
+                    },
                 },
             },
         ],


### PR DESCRIPTION
### What does this pull request do?

- [x] Adds environment variables to the Vitest configuration for test mode
- [x] Updates project service tests to use actual database operations and clears projects before testing
- [x] Removes an unused dependency and adjusts GitHub workflow configurations for testing

### Related Issues

Link all issues related to this pull request

- [x] 🔗 Part of [DEV-80](https://linear.app/4sure-se/issue/DEV-80/change-unit-tests-to-use-the-test-db-instead-of-mocking-the-data)

### Type of Change

Select all that apply:

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Docs
- [ ] 🛠️ Refactoring
- [ ] 🎨 UI/UX Style
- [x] ⚙️ Workflow/Config
- [x] 🧪 Testing

### Screenshots (Optional)

### Additional Information
