### PR TITLE
chore: implement persistent test ordering

### DIFF
--- a/src/app/(main)/projects/[id]/_components/export-pdf/qcp-report.tsx
+++ b/src/app/(main)/projects/[id]/_components/export-pdf/qcp-report.tsx
@@ -278,53 +278,66 @@ const MyDoc = ({ project }: { project: Projects }) => (
                     {/* Data Rows */}
                     {project.projectWorkItem?.map((pjwi, rowIndex) => (
                         <React.Fragment key={rowIndex}>
-                            {pjwi.itemTest.map((cell, cellIndex) => (
-                                <TR key={`test-${rowIndex}-${cellIndex}`}>
-                                    <TD
-                                        style={styles.tdItemNo}
-                                        weighting={0.1}
-                                    >
-                                        {cellIndex === 0 ? pjwi.itemNo : ""}
-                                    </TD>
-                                    <TD
-                                        style={styles.tdDescription}
-                                        weighting={0.4}
-                                    >
-                                        {cellIndex === 0
-                                            ? pjwi.description
-                                            : ""}
-                                    </TD>
-                                    <TD
-                                        style={styles.tdUnit}
-                                        weighting={0.1}
-                                    >
-                                        {cellIndex === 0
-                                            ? abbreviateUnit(pjwi.unit)
-                                            : ""}
-                                    </TD>
-                                    <TD
-                                        style={styles.tdQuantity}
-                                        weighting={0.1}
-                                    >
-                                        {cellIndex === 0 ? pjwi.quantity : ""}
-                                    </TD>
-                                    <TD
-                                        style={styles.tdTestQuantity}
-                                        weighting={0.3}
-                                    >
-                                        {cell.testQuantity} -{" "}
-                                        {cell.testRequired}
-                                    </TD>
-                                </TR>
-                            ))}
+                            {pjwi.itemTest
+                                .sort((a, b) =>
+                                    a.testRequired.localeCompare(
+                                        b.testRequired,
+                                    ),
+                                )
+                                .map((cell, cellIndex) => (
+                                    <TR key={`test-${rowIndex}-${cellIndex}`}>
+                                        <TD
+                                            style={styles.tdItemNo}
+                                            weighting={0.1}
+                                        >
+                                            {cellIndex === 0 ? pjwi.itemNo : ""}
+                                        </TD>
+                                        <TD
+                                            style={styles.tdDescription}
+                                            weighting={0.4}
+                                        >
+                                            {cellIndex === 0
+                                                ? pjwi.description
+                                                : ""}
+                                        </TD>
+                                        <TD
+                                            style={styles.tdUnit}
+                                            weighting={0.1}
+                                        >
+                                            {cellIndex === 0
+                                                ? abbreviateUnit(pjwi.unit)
+                                                : ""}
+                                        </TD>
+                                        <TD
+                                            style={styles.tdQuantity}
+                                            weighting={0.1}
+                                        >
+                                            {cellIndex === 0
+                                                ? pjwi.quantity
+                                                : ""}
+                                        </TD>
+                                        <TD
+                                            style={styles.tdTestQuantity}
+                                            weighting={0.3}
+                                        >
+                                            {cell.testQuantity} -{" "}
+                                            {cell.testRequired}
+                                        </TD>
+                                    </TR>
+                                ))}
 
                             {/* Materials */}
                             {pjwi.materials?.map((material, matIndex) => (
                                 <React.Fragment
                                     key={`mat-${rowIndex}-${matIndex}`}
                                 >
-                                    {material.materialTest.map(
-                                        (matTest, mtIndex) => (
+                                    {material.materialTest
+                                        .sort((a, b) =>
+                                            a.testRequired.localeCompare(
+                                                b.testRequired,
+                                            ),
+                                        )
+                                        .map((matTest, mtIndex) => (
                                             <TR
                                                 key={`mat-test-${rowIndex}-${matIndex}-${mtIndex}`}
                                             >
@@ -378,8 +391,7 @@ const MyDoc = ({ project }: { project: Projects }) => (
                                                     - {matTest.testRequired}
                                                 </TD>
                                             </TR>
-                                        ),
-                                    )}
+                                        ))}
                                 </React.Fragment>
                             ))}
                         </React.Fragment>

--- a/src/app/(main)/projects/[id]/_components/export-pdf/sot-report.tsx
+++ b/src/app/(main)/projects/[id]/_components/export-pdf/sot-report.tsx
@@ -331,73 +331,90 @@ const MyDoc = ({ project }: { project: Projects }) => (
                     {/* Data Rows */}
                     {project.projectWorkItem?.map((pjwi, rowIndex) => (
                         <React.Fragment key={rowIndex}>
-                            {pjwi.itemTest.map((cell, cellIndex) => (
-                                <TR key={`test-${rowIndex}-${cellIndex}`}>
-                                    <TD
-                                        style={styles.tdItemNo}
-                                        weighting={0.07}
-                                    >
-                                        {cellIndex === 0 ? pjwi.itemNo : ""}
-                                    </TD>
-                                    <TD
-                                        style={styles.tdDescription}
-                                        weighting={0.25}
-                                    >
-                                        {cellIndex === 0
-                                            ? pjwi.description
-                                            : ""}
-                                    </TD>
-                                    <TD
-                                        style={styles.tdContractQuantity}
-                                        weighting={0.08}
-                                    >
-                                        {cellIndex === 0 ? pjwi.quantity : ""}
-                                    </TD>
-                                    <TD
-                                        style={styles.tdUnit}
-                                        weighting={0.08}
-                                    >
-                                        <Text style={{ textAlign: "center" }}>
+                            {pjwi.itemTest
+                                .sort((a, b) =>
+                                    a.testRequired.localeCompare(
+                                        b.testRequired,
+                                    ),
+                                )
+                                .map((cell, cellIndex) => (
+                                    <TR key={`test-${rowIndex}-${cellIndex}`}>
+                                        <TD
+                                            style={styles.tdItemNo}
+                                            weighting={0.07}
+                                        >
+                                            {cellIndex === 0 ? pjwi.itemNo : ""}
+                                        </TD>
+                                        <TD
+                                            style={styles.tdDescription}
+                                            weighting={0.25}
+                                        >
                                             {cellIndex === 0
-                                                ? abbreviateUnit(pjwi.unit)
+                                                ? pjwi.description
                                                 : ""}
-                                        </Text>
-                                    </TD>
-                                    <TD
-                                        style={styles.tdMinNumberTotalRequired}
-                                        weighting={0.26}
-                                    >
-                                        {cell.testQuantity} -{" "}
-                                        {cell.testRequired}
-                                    </TD>
-                                    <TD
-                                        style={styles.tdOnFile}
-                                        weighting={0.07}
-                                    >
-                                        {cell.testsOnFile}
-                                    </TD>
-                                    <TD
-                                        style={styles.tdBalance}
-                                        weighting={0.07}
-                                    >
-                                        {cell.balance}
-                                    </TD>
-                                    <TD
-                                        style={
-                                            styles.tdPercentOfWorkAccomplished
-                                        }
-                                        weighting={0.12}
-                                    ></TD>
-                                </TR>
-                            ))}
+                                        </TD>
+                                        <TD
+                                            style={styles.tdContractQuantity}
+                                            weighting={0.08}
+                                        >
+                                            {cellIndex === 0
+                                                ? pjwi.quantity
+                                                : ""}
+                                        </TD>
+                                        <TD
+                                            style={styles.tdUnit}
+                                            weighting={0.08}
+                                        >
+                                            <Text
+                                                style={{ textAlign: "center" }}
+                                            >
+                                                {cellIndex === 0
+                                                    ? abbreviateUnit(pjwi.unit)
+                                                    : ""}
+                                            </Text>
+                                        </TD>
+                                        <TD
+                                            style={
+                                                styles.tdMinNumberTotalRequired
+                                            }
+                                            weighting={0.26}
+                                        >
+                                            {cell.testQuantity} -{" "}
+                                            {cell.testRequired}
+                                        </TD>
+                                        <TD
+                                            style={styles.tdOnFile}
+                                            weighting={0.07}
+                                        >
+                                            {cell.testsOnFile}
+                                        </TD>
+                                        <TD
+                                            style={styles.tdBalance}
+                                            weighting={0.07}
+                                        >
+                                            {cell.balance}
+                                        </TD>
+                                        <TD
+                                            style={
+                                                styles.tdPercentOfWorkAccomplished
+                                            }
+                                            weighting={0.12}
+                                        ></TD>
+                                    </TR>
+                                ))}
 
                             {/* Materials */}
                             {pjwi.materials?.map((material, matIndex) => (
                                 <React.Fragment
                                     key={`mat-${rowIndex}-${matIndex}`}
                                 >
-                                    {material.materialTest.map(
-                                        (matTest, mtIndex) => (
+                                    {material.materialTest
+                                        .sort((a, b) =>
+                                            a.testRequired.localeCompare(
+                                                b.testRequired,
+                                            ),
+                                        )
+                                        .map((matTest, mtIndex) => (
                                             <TR
                                                 key={`mat-test-${rowIndex}-${matIndex}-${mtIndex}`}
                                             >
@@ -471,8 +488,7 @@ const MyDoc = ({ project }: { project: Projects }) => (
                                                     weighting={0.12}
                                                 ></TD>
                                             </TR>
-                                        ),
-                                    )}
+                                        ))}
                                 </React.Fragment>
                             ))}
                         </React.Fragment>

--- a/src/app/(main)/projects/[id]/_components/table/materials-table.tsx
+++ b/src/app/(main)/projects/[id]/_components/table/materials-table.tsx
@@ -19,9 +19,12 @@ export function MaterialsTable({
     onTestCountUpdate,
     isReadOnly = false,
 }: MaterialsTableProps) {
+    const sortedMaterialTests = [...material.materialTest].sort((a, b) =>
+        a.testRequired.localeCompare(b.testRequired),
+    );
     return (
         <>
-            {material.materialTest.map((test, testIndex) => (
+            {sortedMaterialTests.map((test, testIndex) => (
                 <TableRow key={test.id}>
                     <TableCell></TableCell>
                     {testIndex === 0 ? (

--- a/src/app/(main)/projects/[id]/_components/table/work-items-table.tsx
+++ b/src/app/(main)/projects/[id]/_components/table/work-items-table.tsx
@@ -23,6 +23,10 @@ export function WorkItemsTable({
 }: WorkItemsTableProps) {
     const hasItemTests = workItem.itemTest.length > 0;
 
+    const sortedWorkItemTests = [...workItem.itemTest].sort((a, b) =>
+        a.testRequired.localeCompare(b.testRequired),
+    );
+
     return (
         <Fragment>
             <TableRow className="bg-[#FCFCFD]">
@@ -43,26 +47,26 @@ export function WorkItemsTable({
                             {workItem.unit ?? "N/A"}
                         </TableCell>
                         <TableCell className="text-center">
-                            {workItem.itemTest?.[0]?.testRequired ?? "N/A"}
+                            {sortedWorkItemTests?.[0]?.testRequired ?? "N/A"}
                         </TableCell>
                         <TableCell className="text-center">
                             <TestCounter
-                                id={workItem.itemTest[0]?.id}
-                                value={workItem.itemTest[0]?.testsOnFile ?? 0}
+                                id={sortedWorkItemTests[0]?.id}
+                                value={sortedWorkItemTests[0]?.testsOnFile ?? 0}
                                 type="workItem"
                                 updateTestAction={onTestCountUpdate}
                                 isReadOnly={isReadOnly}
                             ></TestCounter>
                         </TableCell>
                         <TableCell className="text-center">
-                            {workItem.itemTest?.[0]?.balance ?? "N/A"}
+                            {sortedWorkItemTests?.[0]?.balance ?? "N/A"}
                         </TableCell>
                         <TableCell className="text-center">
                             <TestStatus
                                 testsOnFile={
-                                    workItem.itemTest?.[0]?.testsOnFile ?? 0
+                                    sortedWorkItemTests?.[0]?.testsOnFile ?? 0
                                 }
-                                balance={workItem.itemTest?.[0]?.balance ?? 0}
+                                balance={sortedWorkItemTests?.[0]?.balance ?? 0}
                             ></TestStatus>
                         </TableCell>
                     </>
@@ -73,7 +77,7 @@ export function WorkItemsTable({
             </TableRow>
 
             {/* Additional item tests (if any) */}
-            {workItem.itemTest.slice(1).map((test) => (
+            {sortedWorkItemTests.slice(1).map((test) => (
                 <TableRow key={test.id}>
                     <TableCell></TableCell>
                     <TableCell></TableCell>


### PR DESCRIPTION
### What does this pull request do?

- [x] sort work item and material test array alphabetically


### Related Issues

Link all issues related to this pull request

- [x] 🔗 Part of [DEV-87](https://linear.app/4sure-se/issue/DEV-87/persistent-ordering-of-tests-within-project-work-item-details-table)

### Type of Change

Select all that apply:

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Docs
- [ ] 🛠️ Refactoring
- [x] 🎨 UI/UX Style
- [ ] ⚙️ Workflow/Config
- [ ] 🧪 Testing

### Screenshots (Optional)
![Screenshot 2025-05-10 133236](https://github.com/user-attachments/assets/fb3bd52c-45d1-45c0-80db-ce5f54a312a4)
![Screenshot 2025-05-10 133811](https://github.com/user-attachments/assets/f31fc339-c843-44f2-a382-1efa246122df)
![Screenshot 2025-05-10 134717](https://github.com/user-attachments/assets/f8b50e6a-a686-410b-b4af-9a38ba63064c)

### Additional Information
