### PR TITLE
chore: add finish setup button component for better ux

### DIFF
--- a/src/app/(main)/projects/[id]/work-items/_components/finish-setup-button.tsx
+++ b/src/app/(main)/projects/[id]/work-items/_components/finish-setup-button.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import ButtonWithLoader from "@/components/custom/button-with-loader";
+import { CheckCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+
+interface FinishSetupButtonProps {
+    projectId: string;
+}
+
+export function FinishSetupButton({ projectId }: FinishSetupButtonProps) {
+    const router = useRouter();
+    const [isNavigating, startNavigation] = useTransition();
+
+    const handleFinish = () => {
+        startNavigation(() => {
+            router.push(`/projects/${projectId}`);
+        });
+    };
+
+    return (
+        <ButtonWithLoader
+            className="cursor-pointer"
+            onClick={handleFinish}
+            disabled={isNavigating}
+            isPending={isNavigating}
+            text={"Done"}
+            loadingText="Proceeding..."
+            icon={<CheckCircle className="mr-2 h-4 w-4" />}
+        ></ButtonWithLoader>
+    );
+}

--- a/src/app/(main)/projects/[id]/work-items/page.tsx
+++ b/src/app/(main)/projects/[id]/work-items/page.tsx
@@ -6,6 +6,7 @@ import { deleteProjectWorkItem } from "@/server/actions/projects/delete-project-
 import { ProjectService } from "@/server/services/project.service";
 import { WorkItemService } from "@/server/services/work-item.service";
 import { AddProjectWorkItemForm, ProjectWorkItemsTable } from "./_components";
+import { FinishSetupButton } from "./_components/finish-setup-button";
 
 export default async function ManageWorkItemsPage({
     params,
@@ -13,6 +14,7 @@ export default async function ManageWorkItemsPage({
     params: Promise<{ id: string }>;
 }) {
     const { id } = await params;
+
     const { data: project, error: getProjectError } = await tryCatch(
         ProjectService.getProjectById(id),
     );
@@ -47,10 +49,14 @@ export default async function ManageWorkItemsPage({
                 projectId={id}
                 workItemDefinitions={workItemDefinitions}
             />
+
             <ProjectWorkItemsTable
                 data={projectWorkItems}
                 onDeleteAction={deleteProjectWorkItem}
             />
+            <div className="mt-6 flex justify-end">
+                <FinishSetupButton projectId={id} />
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
### What does this pull request do?

- [x] Adds a finish setup button on the manage work items page that redirects to the project details page

### Related Issues

Link all issues related to this pull request

- [x] 🔗 Part of [DEV-76](https://linear.app/4sure-se/issue/DEV-76/redirect-to-project-details-page-after-adding-initial-project-work)

### Type of Change

Select all that apply:

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Docs
- [ ] 🛠️ Refactoring
- [x] 🎨 UI/UX Style
- [ ] ⚙️ Workflow/Config
- [ ] 🧪 Testing

### Screenshots (Optional)
![image](https://github.com/user-attachments/assets/964e1a6c-2c6e-4fd2-96f1-d82e35cd1810)
![image](https://github.com/user-attachments/assets/8d9b6a3d-90e4-4f6d-b868-de6134547e36)

### Additional Information
