### PR TITLE
test: add unit tests for log-in, reset-password and sign-up

### DIFF
--- a/src/server/actions/auth/__tests__/log-in.test.ts
+++ b/src/server/actions/auth/__tests__/log-in.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { logIn } from "../log-in";
+
+vi.mock("@/lib/supabase/server", () => ({
+    createClient: vi.fn().mockImplementation(() => ({
+        auth: {
+            signInWithPassword: vi
+                .fn()
+                .mockImplementation(({ email, password }) => {
+                    if (
+                        email === "test@gmail.com" &&
+                        password === "Password123"
+                    ) {
+                        return { error: null };
+                    }
+                    return {
+                        error: { message: "Invalid login credentials" },
+                    };
+                }),
+        },
+    })),
+}));
+
+describe("logIn function", () => {
+    let formData: FormData;
+
+    beforeEach(() => {
+        formData = new FormData();
+    });
+
+    test("successful login with valid credentials", async () => {
+        formData.append("email", "test@gmail.com");
+        formData.append("password", "Password123");
+
+        const result = await logIn(formData);
+
+        expect(result).toEqual({
+            success: true,
+            message: "Successfully logged in",
+        });
+    });
+
+    test("failed login with invalid credentials", async () => {
+        formData.append("email", "wrong@gmail.com");
+        formData.append("password", "WrongPassword");
+        const result = await logIn(formData);
+
+        expect(result).toEqual({
+            error: "Invalid login credentials",
+            success: false,
+        });
+    });
+});

--- a/src/server/actions/auth/__tests__/reset-password.test.ts
+++ b/src/server/actions/auth/__tests__/reset-password.test.ts
@@ -69,9 +69,7 @@ describe("resetPassword function", () => {
     test("handles thrown exceptions", async () => {
         formData.append("password", "ThrowError");
 
-        const createClientMock =
-            supabaseServer.createClient as unknown as ReturnType<typeof vi.fn>;
-        createClientMock.mockImplementationOnce(() => {
+        vi.mocked(supabaseServer).createClient.mockImplementationOnce(() => {
             throw new Error("Unexpected error");
         });
 

--- a/src/server/actions/auth/__tests__/reset-password.test.ts
+++ b/src/server/actions/auth/__tests__/reset-password.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { resetPassword } from "../reset-password";
+
+import * as supabaseServer from "@/lib/supabase/server";
+
+vi.mock("@/lib/supabase/server", () => ({
+    createClient: vi.fn().mockImplementation(() => ({
+        auth: {
+            updateUser: vi.fn().mockImplementation(({ password }) => {
+                if (password === "ValidPassword123") {
+                    return { error: null };
+                }
+                if (password === "short") {
+                    return {
+                        error: {
+                            message: "Password should be at least 8 characters",
+                        },
+                    };
+                }
+                return {
+                    error: {
+                        message: "An error occurred during password reset",
+                    },
+                };
+            }),
+        },
+    })),
+}));
+
+describe("resetPassword function", () => {
+    let formData: FormData;
+
+    beforeEach(() => {
+        formData = new FormData();
+
+        vi.spyOn(console, "error").mockImplementation(() => {
+            return;
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("successful password reset with valid password", async () => {
+        formData.append("password", "ValidPassword123");
+
+        const result = await resetPassword(formData);
+
+        expect(result).toEqual({
+            success: true,
+            message:
+                "Password reset successfully. You can now log in with your new password.",
+        });
+    });
+
+    test("failed password reset with error from Supabase", async () => {
+        formData.append("password", "short");
+
+        const result = await resetPassword(formData);
+
+        expect(result).toEqual({
+            error: "An unexpected error occurred. Please try again.",
+            success: false,
+        });
+        expect(console.error).toHaveBeenCalled();
+    });
+
+    test("handles thrown exceptions", async () => {
+        formData.append("password", "ThrowError");
+
+        const createClientMock =
+            supabaseServer.createClient as unknown as ReturnType<typeof vi.fn>;
+        createClientMock.mockImplementationOnce(() => {
+            throw new Error("Unexpected error");
+        });
+
+        const result = await resetPassword(formData);
+
+        expect(result).toEqual({
+            error: "An unexpected error occurred. Please try again.",
+            success: false,
+        });
+        expect(console.error).toHaveBeenCalled();
+    });
+});

--- a/src/server/actions/auth/__tests__/sign-up.test.ts
+++ b/src/server/actions/auth/__tests__/sign-up.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { signUp } from "../sign-up";
+import { validateEmail } from "../validate-email";
+
+vi.mock("../validate-email", () => ({
+    validateEmail: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+    createClient: vi.fn().mockImplementation(() => ({
+        auth: {
+            signUp: vi.fn().mockImplementation(({ email }) => {
+                if (email === "newuser@example.com") {
+                    return { error: null };
+                }
+                if (email === "existing@example.com") {
+                    return {
+                        error: { message: "User already registered" },
+                    };
+                }
+                return {
+                    error: { message: "An error occurred during signup" },
+                };
+            }),
+        },
+    })),
+}));
+
+describe("signUp function", () => {
+    let formData: FormData;
+
+    beforeEach(() => {
+        formData = new FormData();
+        vi.mocked(validateEmail).mockReset();
+    });
+
+    test("successful signup with valid data", async () => {
+        formData.append("email", "newuser@example.com");
+        formData.append("password", "Password123");
+        formData.append("fullName", "New User");
+
+        vi.mocked(validateEmail).mockResolvedValue({
+            isValid: true,
+        });
+
+        const result = await signUp(formData);
+
+        expect(validateEmail).toHaveBeenCalledWith("newuser@example.com");
+        expect(result).toEqual({
+            success: true,
+            message:
+                "Check your email for confirmation instructions. You will be redirected to login after confirming.",
+        });
+    });
+
+    test("failed signup with invalid email", async () => {
+        formData.append("email", "invalidemail@example.com");
+        formData.append("password", "Password123");
+        formData.append("fullName", "Invalid User");
+
+        vi.mocked(validateEmail).mockResolvedValue({
+            isValid: false,
+            error: "This email is already in use. Please try logging in instead or reset your password.",
+        });
+
+        const result = await signUp(formData);
+
+        expect(validateEmail).toHaveBeenCalledWith("invalidemail@example.com");
+        expect(result).toEqual({
+            error: "This email is already in use. Please try logging in instead or reset your password.",
+            success: false,
+            field: "email",
+        });
+    });
+
+    test("failed signup with existing email", async () => {
+        formData.append("email", "existing@example.com");
+        formData.append("password", "Password123");
+        formData.append("fullName", "Existing User");
+
+        vi.mocked(validateEmail).mockResolvedValue({
+            isValid: true,
+        });
+
+        const result = await signUp(formData);
+
+        expect(validateEmail).toHaveBeenCalledWith("existing@example.com");
+        expect(result).toEqual({
+            error: "User already registered",
+            success: false,
+        });
+    });
+});


### PR DESCRIPTION
### What does this pull request do?

- [x] List all changes that were achieved
- [x] successfully  added unit test for login, sign-up, and reset-password

### Related Issues

Link all issues related to this pull request

- [x] 🔗 Part of [DEV-98](https://linear.app/4sure-se/issue/DEV-98/write-unit-tests-for-authentication)

### Type of Change

Select all that apply:

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 📚 Docs
- [ ] 🛠️ Refactoring
- [ ] 🎨 UI/UX Style
- [ ] ⚙️ Workflow/Config
- [x] 🧪 Testing

### Screenshots (Optional)
![image](https://github.com/user-attachments/assets/a15d8902-880b-46ce-9880-c0b2b2911a72)


### Additional Information
